### PR TITLE
[#28] Create protected route

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { CssBaseline } from '@mui/material';
 import { ThemeProvider } from '@mui/material/styles';
 import { theme } from './themes/theme';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 import Login from './pages/Login/Login';
 import Signup from './pages/SignUp/SignUp';
 import Dashboard from './pages/Dashboard/Dashboard';
@@ -26,8 +27,8 @@ function App(): JSX.Element {
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
-                <Route exact path="/dashboard" component={Dashboard} />
-                <Route path="/profile/settings" component={Settings} />
+                <ProtectedRoute exact path="/dashboard" component={Dashboard} />
+                <ProtectedRoute path="/profile/settings" component={Settings} />
                 <Route path="*">
                   <NotFound />
                 </Route>

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,37 +1,22 @@
-import React from 'react';
-import { RouteComponentProps } from 'react-router';
 import { Route, Redirect, RouteProps } from 'react-router-dom';
 import { useAuth } from '../../context/useAuthContext';
 
-interface ProtectedRoute extends RouteProps {
-  component: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any> | undefined;
-}
-
-export default function ProtectedRoute({ component: Component, ...rest }: ProtectedRoute) {
+export default function ProtectedRoute({ ...props }: RouteProps): JSX.Element {
   const { loggedInUser } = useAuth();
   const redirectPath = '/login';
 
-  if (!Component) return null;
-
-  return (
-    <Route
-      {...rest}
-      render={(props) => {
-        if (loggedInUser) {
-          return <Component {...props} />;
-        } else {
-          return (
-            <Redirect
-              to={{
-                pathname: redirectPath,
-                state: {
-                  from: props.location,
-                },
-              }}
-            />
-          );
-        }
-      }}
-    />
-  );
+  if (loggedInUser) {
+    return <Route {...props} />;
+  } else {
+    return (
+      <Redirect
+        to={{
+          pathname: redirectPath,
+          state: {
+            from: props.location,
+          },
+        }}
+      />
+    );
+  }
 }

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,3 +1,4 @@
+import { CircularProgress, Stack } from '@mui/material';
 import { Route, Redirect, RouteProps } from 'react-router-dom';
 import { useAuth } from '../../context/useAuthContext';
 
@@ -5,7 +6,13 @@ export default function ProtectedRoute({ ...props }: RouteProps): JSX.Element {
   const { loggedInUser } = useAuth();
   const redirectPath = '/login';
 
-  if (loggedInUser) {
+  if (typeof loggedInUser === 'undefined')
+    return (
+      <Stack alignItems="center" marginTop={'20vh'}>
+        <CircularProgress />
+      </Stack>
+    );
+  else if (loggedInUser) {
     return <Route {...props} />;
   } else {
     return (

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { ExtractRouteParams, RouteChildrenProps, RouteComponentProps } from 'react-router';
+import { Route, Redirect, RouteProps } from 'react-router-dom';
+import { JsxElement } from 'typescript';
+import { useAuth } from '../../context/useAuthContext';
+
+interface ProtectedRoute extends RouteProps {
+  component: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any> | undefined;
+}
+
+export default function ProtectedRoute({ component: Component, ...rest }: ProtectedRoute) {
+  const { loggedInUser } = useAuth();
+  const redirectPath = '/login';
+
+  if (!Component) return null;
+
+  return (
+    <Route
+      {...rest}
+      render={(props) => {
+        if (loggedInUser) {
+          return <Component {...props} />;
+        } else {
+          return (
+            <Redirect
+              to={{
+                pathname: redirectPath,
+                state: {
+                  from: props.location,
+                },
+              }}
+            />
+          );
+        }
+      }}
+    />
+  );
+}

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { ExtractRouteParams, RouteChildrenProps, RouteComponentProps } from 'react-router';
+import { RouteComponentProps } from 'react-router';
 import { Route, Redirect, RouteProps } from 'react-router-dom';
-import { JsxElement } from 'typescript';
 import { useAuth } from '../../context/useAuthContext';
 
 interface ProtectedRoute extends RouteProps {


### PR DESCRIPTION
### What this PR does (required):
- Creates the ProtectedRoute component:  a superset of the react-router route component that adds an authorization check to verify if the user is logged in
- Implements the ProtectedRoute component for /dashboard and /profile/settings paths 
- When entering a protected route while not logged in, the page will return to the login page

### Screenshots / Videos (front-end only):
![msedge_MSEhZGBMST](https://user-images.githubusercontent.com/25715300/151641094-2a8d9522-2e09-4a6d-96ef-7a7b4997a2b8.gif)

### Any information needed to test this feature (required):
- Enter the login page and enter a protected route in the url when signed out
- The protected routes currently implemented are /dashboard and /profile/settings 
