### PR TITLE
Implement Profile Listings UI on Dashboard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,8 +31,8 @@ function App(): JSX.Element {
                   <Route exact path="/" component={LandingPage} />
                   <Route exact path="/login" component={Login} />
                   <Route exact path="/signup" component={Signup} />
-                  <Route exact path="/dashboard" component={Dashboard} />
-                  <Route path="/profile/settings" component={Settings} />
+                  <ProtectedRoute exact path="/dashboard" component={Dashboard} />
+                  <ProtectedRoute path="/profile/settings" component={Settings} />
                   <Route path="*">
                     <NotFound />
                   </Route>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,30 +14,34 @@ import { SnackBarProvider } from './context/useSnackbarContext';
 import { Navbar } from './components/Navbar/Navbar';
 import Settings from './pages/Settings/Settings';
 import NotFound from './pages/NotFound/NotFound';
+import { LocalizationProvider } from '@mui/lab';
+import AdapterDateFns from '@mui/lab/AdapterDateFns';
 
 function App(): JSX.Element {
   return (
     <ThemeProvider theme={theme}>
-      <BrowserRouter>
-        <SnackBarProvider>
-          <AuthProvider>
-            <SocketProvider>
-              <CssBaseline />
-              <Navbar />
-              <Switch>
-                <Route exact path="/" component={LandingPage} />
-                <Route exact path="/login" component={Login} />
-                <Route exact path="/signup" component={Signup} />
-                <Route exact path="/dashboard" component={Dashboard} />
-                <Route path="/profile/settings" component={Settings} />
-                <Route path="*">
-                  <NotFound />
-                </Route>
-              </Switch>
-            </SocketProvider>
-          </AuthProvider>
-        </SnackBarProvider>
-      </BrowserRouter>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <BrowserRouter>
+          <SnackBarProvider>
+            <AuthProvider>
+              <SocketProvider>
+                <CssBaseline />
+                <Navbar />
+                <Switch>
+                  <Route exact path="/" component={LandingPage} />
+                  <Route exact path="/login" component={Login} />
+                  <Route exact path="/signup" component={Signup} />
+                  <Route exact path="/dashboard" component={Dashboard} />
+                  <Route path="/profile/settings" component={Settings} />
+                  <Route path="*">
+                    <NotFound />
+                  </Route>
+                </Switch>
+              </SocketProvider>
+            </AuthProvider>
+          </SnackBarProvider>
+        </BrowserRouter>
+      </LocalizationProvider>
     </ThemeProvider>
   );
 }

--- a/client/src/components/Cards/ProfileCard.tsx
+++ b/client/src/components/Cards/ProfileCard.tsx
@@ -1,0 +1,79 @@
+import { Card, CardActionArea, CardContent, Typography, Rating, Box, Avatar } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+
+const useStyles = makeStyles({
+  root: {
+    width: '17rem',
+    height: '20rem',
+    boxShadow: 'none',
+    margin: 20,
+  },
+  cardFooter: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    borderTop: '1px solid #D3D3D3',
+    padding: '1rem 1.25rem',
+  },
+  location: {
+    display: 'flex',
+    gap: 2,
+  },
+  avatar: {
+    '&.MuiAvatar-root': {
+      width: '6rem',
+      height: '6rem',
+      margin: '0.5rem auto',
+    },
+  },
+});
+
+interface ProfileCardProps {
+  photo: string;
+  name: string;
+  caption?: string;
+  rating?: number;
+  description: string;
+  location: string;
+  pay: number;
+}
+
+const ProfileCard: React.FC<ProfileCardProps> = ({ photo, name, caption, rating, description, location, pay }) => {
+  const classes = useStyles();
+  return (
+    <Card className={classes.root}>
+      <CardActionArea>
+        <CardContent sx={{ display: 'flex', flexDirection: 'column', justifyItems: 'center' }}>
+          <Avatar alt="Profile Photo" src={photo} className={classes.avatar} />
+          <Typography variant="h5" component="h2" fontWeight="500" textAlign="center">
+            {name}
+          </Typography>
+          <Typography gutterBottom variant="caption" color="textSecondary" fontWeight={500} component="caption">
+            {caption}
+          </Typography>
+          <Box sx={{ margin: '0.25rem auto' }}>
+            <Rating value={rating} precision={0.5} size="small" readOnly />
+          </Box>
+          <Box sx={{ width: '70%', margin: '0 auto 0.5rem' }}>
+            <Typography gutterBottom textAlign="center" variant="body2" fontWeight={500} component="p">
+              {description}
+            </Typography>
+          </Box>
+        </CardContent>
+        <Box className={classes.cardFooter}>
+          <Box className={classes.location}>
+            <LocationOnIcon color="primary" />
+            <Typography variant="subtitle2" color="textSecondary" fontWeight={400}>
+              {location}
+            </Typography>
+          </Box>
+          <Typography variant="body2" fontWeight={600}>
+            ${pay}/hr
+          </Typography>
+        </Box>
+      </CardActionArea>
+    </Card>
+  );
+};
+
+export default ProfileCard;

--- a/client/src/context/useAuthContext.tsx
+++ b/client/src/context/useAuthContext.tsx
@@ -58,9 +58,6 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
         } else {
           // don't need to provide error feedback as this just means user doesn't have saved cookies or the cookies have not been authenticated on the backend
           setLoggedInUser(null);
-          if (!(history.location.pathname === '/signup')) {
-            history.push('/');
-          }
         }
       });
     };

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -1,33 +1,149 @@
-import React, { useEffect } from 'react';
-import { useAuth } from '../../context/useAuthContext';
+import { useEffect, useState } from 'react';
 import { useSocket } from '../../context/useSocketContext';
-import { useHistory } from 'react-router-dom';
-import { CircularProgress, Grid, Typography } from '@mui/material';
+import { Box, Button, Grid, InputAdornment, TextField, Typography } from '@mui/material';
 import PageContainer from '../../components/PageContainer/PageContainer';
+import ProfileCard from '../../components/Cards/ProfileCard';
+import useStyles from './useStyles';
+import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
+import { DateRange, DateRangePicker, LocalizationProvider } from '@mui/lab';
+import AdapterDateFns from '@mui/lab/AdapterDateFns';
+import React from 'react';
 
 export default function Dashboard(): JSX.Element {
-  const { loggedInUser } = useAuth();
+  const classes = useStyles();
   const { initSocket } = useSocket();
-  const history = useHistory();
+  const [location, setLocation] = useState<string>('');
+  const [dateRange, setDateRange] = useState<DateRange<Date>>([null, null]);
 
   useEffect(() => {
     initSocket();
   }, [initSocket]);
 
-  if (loggedInUser === undefined) return <CircularProgress />;
-  if (!loggedInUser) {
-    history.push('/login');
-    // loading for a split seconds until history.push works
-    return <CircularProgress />;
-  }
+  const profileCards = [
+    {
+      name: 'Norma Byers',
+      photo:
+        'https://images.unsplash.com/photo-1525134479668-1bee5c7c6845?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80',
+      caption: 'Loving pet sitter',
+      rating: 4.5,
+      description: 'Dog sitting, cat sitting, pocket pet and bird care',
+      location: 'Toronto, Ontario',
+      pay: 14,
+    },
+    {
+      name: 'Jessica Pearson',
+      photo:
+        'https://images.unsplash.com/photo-1606122017369-d782bbb78f32?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=764&q=80',
+      caption: 'Loving pet sitter',
+      rating: 4,
+      description: 'I have had dogs as pets for most of my life',
+      location: 'Toronto, Ontario',
+      pay: 15,
+    },
+    {
+      name: 'Charles Compton',
+      photo:
+        'https://images.unsplash.com/photo-1484517186945-df8151a1a871?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1949&q=80',
+      caption: 'Passionate pet sitter',
+      rating: 5,
+      description: 'I provide dog walking and pet sitting services',
+      location: 'Toronto, Ontario',
+      pay: 20,
+    },
+    {
+      name: 'Norma Byers',
+      photo:
+        'https://images.unsplash.com/photo-1525134479668-1bee5c7c6845?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80',
+      caption: 'Loving pet sitter',
+      rating: 4.5,
+      description: 'Dog sitting, cat sitting, pocket pet and bird care',
+      location: 'Toronto, Ontario',
+      pay: 14,
+    },
+    {
+      name: 'Jessica Pearson',
+      photo:
+        'https://images.unsplash.com/photo-1606122017369-d782bbb78f32?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=764&q=80',
+      caption: 'Loving pet sitter',
+      rating: 4,
+      description: 'I have had dogs as pets for most of my life',
+      location: 'Toronto, Ontario',
+      pay: 15,
+    },
+    {
+      name: 'Charles Compton',
+      photo:
+        'https://images.unsplash.com/photo-1484517186945-df8151a1a871?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1949&q=80',
+      caption: 'Passionate pet sitter',
+      rating: 5,
+      description: 'I provide dog walking and pet sitting services',
+      location: 'Toronto, Ontario',
+      pay: 20,
+    },
+  ];
 
   return (
     <PageContainer>
-      <Grid container>
+      <Grid container direction="column" spacing={5}>
         <Grid xs={12} item>
-          <Typography sx={{ textAlign: 'center' }} variant="h4">
-            Search Profiles
+          <Typography sx={{ textAlign: 'center', fontWeight: 600 }} p={'2rem 0 0'} variant="h4">
+            Your search results
           </Typography>
+        </Grid>
+        <Grid xs={12} item textAlign="center">
+          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            <TextField
+              id="location"
+              name="location"
+              className={classes.boldText}
+              value={location}
+              sx={{ width: '18rem' }}
+              onChange={(e) => {
+                setLocation(e.target.value);
+              }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchRoundedIcon color="primary" />
+                  </InputAdornment>
+                ),
+              }}
+            />
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
+              <DateRangePicker
+                startText="Check-in"
+                endText="Check-out"
+                value={dateRange}
+                onChange={(newDateRange) => {
+                  setDateRange(newDateRange);
+                }}
+                renderInput={(startProps, endProps) => (
+                  <React.Fragment>
+                    <TextField className={classes.boldText} {...startProps} />
+                    <TextField className={classes.boldText} {...endProps} />
+                  </React.Fragment>
+                )}
+              />
+            </LocalizationProvider>
+          </Box>
+        </Grid>
+        <Grid xs={12} item>
+          <Box sx={{ width: '85%', margin: '2rem auto 0' }}>
+            <Grid container justifyContent="space-evenly">
+              {profileCards.map((profileCard, i) => {
+                return (
+                  <Grid key={i} item>
+                    <ProfileCard {...profileCard} />
+                  </Grid>
+                );
+              })}
+              <Grid item xs={12} className={classes.buttonContainer}>
+                <Button variant="outlined" color="secondary" size="large">
+                  Show more
+                </Button>
+              </Grid>
+            </Grid>
+          </Box>
         </Grid>
       </Grid>
     </PageContainer>

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -21,6 +21,7 @@ export default function Dashboard(): JSX.Element {
 
   const profileCards = [
     {
+      id: 'b5a02958-e5ff-4969-ad3b-0d2ddc5f129e',
       name: 'Norma Byers',
       photo:
         'https://images.unsplash.com/photo-1525134479668-1bee5c7c6845?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80',
@@ -31,6 +32,7 @@ export default function Dashboard(): JSX.Element {
       pay: 14,
     },
     {
+      id: '2dfb07e8-980a-4e9f-a7e2-4c87479ae627',
       name: 'Jessica Pearson',
       photo:
         'https://images.unsplash.com/photo-1606122017369-d782bbb78f32?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=764&q=80',
@@ -41,6 +43,7 @@ export default function Dashboard(): JSX.Element {
       pay: 15,
     },
     {
+      id: '86689e76-b4c3-41a1-9e68-9bffe4291df5',
       name: 'Charles Compton',
       photo:
         'https://images.unsplash.com/photo-1484517186945-df8151a1a871?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1949&q=80',
@@ -51,6 +54,7 @@ export default function Dashboard(): JSX.Element {
       pay: 20,
     },
     {
+      id: 'aa523eb0-ca63-40a8-8f6d-75b023f3296f',
       name: 'Norma Byers',
       photo:
         'https://images.unsplash.com/photo-1525134479668-1bee5c7c6845?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80',
@@ -61,6 +65,7 @@ export default function Dashboard(): JSX.Element {
       pay: 14,
     },
     {
+      id: 'df8ea58a-0101-4958-9612-50faeee53721',
       name: 'Jessica Pearson',
       photo:
         'https://images.unsplash.com/photo-1606122017369-d782bbb78f32?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=764&q=80',
@@ -71,6 +76,7 @@ export default function Dashboard(): JSX.Element {
       pay: 15,
     },
     {
+      id: 'a6bdc99c-3378-4737-8a40-603a75403c34',
       name: 'Charles Compton',
       photo:
         'https://images.unsplash.com/photo-1484517186945-df8151a1a871?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1949&q=80',
@@ -81,6 +87,14 @@ export default function Dashboard(): JSX.Element {
       pay: 20,
     },
   ];
+
+  const profileItems = profileCards.map((profileCard) => {
+    return (
+      <Grid key={profileCard.id} item>
+        <ProfileCard {...profileCard} />
+      </Grid>
+    );
+  });
 
   return (
     <PageContainer>
@@ -130,13 +144,7 @@ export default function Dashboard(): JSX.Element {
         <Grid xs={12} item>
           <Box sx={{ width: '85%', margin: '2rem auto 0' }}>
             <Grid container justifyContent="space-evenly">
-              {profileCards.map((profileCard, i) => {
-                return (
-                  <Grid key={i} item>
-                    <ProfileCard {...profileCard} />
-                  </Grid>
-                );
-              })}
+              {profileItems}
               <Grid item xs={12} className={classes.buttonContainer}>
                 <Button variant="outlined" color="secondary" size="large">
                   Show more

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -5,8 +5,7 @@ import PageContainer from '../../components/PageContainer/PageContainer';
 import ProfileCard from '../../components/Cards/ProfileCard';
 import useStyles from './useStyles';
 import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
-import { DateRange, DateRangePicker, LocalizationProvider } from '@mui/lab';
-import AdapterDateFns from '@mui/lab/AdapterDateFns';
+import { DateRange, DateRangePicker } from '@mui/lab';
 import React from 'react';
 
 export default function Dashboard(): JSX.Element {
@@ -123,22 +122,20 @@ export default function Dashboard(): JSX.Element {
                 ),
               }}
             />
-            <LocalizationProvider dateAdapter={AdapterDateFns}>
-              <DateRangePicker
-                startText="Check-in"
-                endText="Check-out"
-                value={dateRange}
-                onChange={(newDateRange) => {
-                  setDateRange(newDateRange);
-                }}
-                renderInput={(startProps, endProps) => (
-                  <React.Fragment>
-                    <TextField className={classes.boldText} {...startProps} />
-                    <TextField className={classes.boldText} {...endProps} />
-                  </React.Fragment>
-                )}
-              />
-            </LocalizationProvider>
+            <DateRangePicker
+              startText="Check-in"
+              endText="Check-out"
+              value={dateRange}
+              onChange={(newDateRange) => {
+                setDateRange(newDateRange);
+              }}
+              renderInput={(startProps, endProps) => (
+                <React.Fragment>
+                  <TextField className={classes.boldText} {...startProps} />
+                  <TextField className={classes.boldText} {...endProps} />
+                </React.Fragment>
+              )}
+            />
           </Box>
         </Grid>
         <Grid xs={12} item>

--- a/client/src/pages/Dashboard/useStyles.ts
+++ b/client/src/pages/Dashboard/useStyles.ts
@@ -1,0 +1,24 @@
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles(() => ({
+  boldText: {
+    '&.MuiTextField-root *': {
+      fontWeight: '700',
+    },
+  },
+  buttonContainer: {
+    '&.MuiGrid-item': {
+      marginTop: '3rem',
+      display: 'flex',
+      justifyContent: 'center',
+      alignContent: 'center',
+    },
+    '&.MuiGrid-item .MuiButton-outlinedSecondary': {
+      color: 'black',
+      padding: '1rem 3rem',
+      fontWeight: 600,
+    },
+  },
+}));
+
+export default useStyles;


### PR DESCRIPTION
### What this PR does (required):
- Resolves #21
- Updates Dashboard to show Profile Listings
- Creates new Profile Card for Profile Listings
- Allows users not logged in to view the Dashboard

### Screenshots / Videos (front-end only):
- Navigate to Dashboard (/dashboard)
<img width="978" alt="chrome_DaF2QtPLXv" src="https://user-images.githubusercontent.com/18078583/154368628-49df4e64-fe5c-4132-ae38-5bc683471106.png">

### Any information needed to test this feature (required):
- Navigate to Dashboard (/dashboard)

### Any issues with the current functionality (optional):
- I can't get the date range picker to match the mock
- The integration from Landing Page to Dashboard will be addressed in the next ticket
- I plan on removing the hard-coded profiles during the integration phase
