### PR TITLE
Create profile details page ui

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import Settings from './pages/Settings/Settings';
 import NotFound from './pages/NotFound/NotFound';
 import { LocalizationProvider } from '@mui/lab';
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
+import Profile from './pages/Profile/Profile';
 
 function App(): JSX.Element {
   return (
@@ -36,6 +37,7 @@ function App(): JSX.Element {
                   <ProtectedRoute exact path="/dashboard" component={Dashboard} />
                   <ProtectedRoute path="/my-jobs" component={Bookings} />
                   <ProtectedRoute path="/profile/settings" component={Settings} />
+                  <ProtectedRoute exact path="/profile/:id" component={Profile} />
                   <Route path="*">
                     <NotFound />
                   </Route>

--- a/client/src/pages/Profile/DetailsCard/DetailsCard.tsx
+++ b/client/src/pages/Profile/DetailsCard/DetailsCard.tsx
@@ -1,4 +1,4 @@
-import { Paper, Typography, Stack, Avatar, Grid } from '@mui/material';
+import { Paper, Typography, Stack, Avatar, Grid, Card, CardMedia, CardContent } from '@mui/material';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 
 interface detailsCardData {
@@ -28,54 +28,57 @@ export default function DetailsCard(): JSX.Element {
   };
 
   return (
-    <Paper elevation={3}>
-      <Stack direction="column" justifyContent="center" alignItems="center">
-        <img
-          src={card.coverImg}
-          alt="Cover photo"
-          width="100%"
-          height="300"
-          style={{ objectFit: 'cover', marginBottom: -100, borderRadius: '4px' }}
-        />
-        <Avatar
-          alt="Avatar photo"
-          src={card.avatarImg}
-          sx={{ height: 200, width: 200, border: '7px solid white', boxShadow: '2px 3px 20px 2px rgb(0 0 0 / 10%)' }}
-        />
-        <Typography variant="h4" marginTop={2} fontWeight="bold">
-          {card.name}
-        </Typography>
-        <Typography variant="subtitle1" color="text.disabled" fontWeight="bold">
-          {card.subtitle}
-        </Typography>
-        <Stack direction="row" spacing={1} marginTop={3}>
-          <LocationOnIcon color="primary"></LocationOnIcon>
-          <Typography variant="subtitle1" color="text.disabled" fontWeight="bold">
-            {card.location}
+    <Card>
+      <CardMedia
+        component="img"
+        src={card.coverImg}
+        alt="Cover photo"
+        width="100%"
+        height="300"
+        style={{ marginBottom: -120 }}
+      />
+      <CardContent>
+        <Stack direction="column" justifyContent="center" alignItems="center">
+          <Avatar
+            alt="Avatar photo"
+            src={card.avatarImg}
+            sx={{ height: 200, width: 200, border: '7px solid white', boxShadow: '2px 3px 20px 2px rgb(0 0 0 / 10%)' }}
+          />
+          <Typography variant="h4" marginTop={2} fontWeight="bold">
+            {card.name}
           </Typography>
+          <Typography variant="subtitle1" color="text.disabled" fontWeight="bold">
+            {card.subtitle}
+          </Typography>
+          <Stack direction="row" spacing={1} marginTop={3}>
+            <LocationOnIcon color="primary"></LocationOnIcon>
+            <Typography variant="subtitle1" color="text.disabled" fontWeight="bold">
+              {card.location}
+            </Typography>
+          </Stack>
+          <Typography variant="h5" fontWeight="bold" marginTop={4} paddingX={4} alignSelf="start">
+            About Me
+          </Typography>
+          <Typography variant="body1" marginTop={2} paddingX={4}>
+            {card.description}
+          </Typography>
+          <Grid container spacing={2} sx={{ paddingX: 4, marginTop: 4, marginBottom: 4 }}>
+            {card.images.map((item) => {
+              return (
+                <Grid item xs={4} sm={3} md={3} lg={2.4} xl={2} key={item.toString()}>
+                  <img
+                    src={item}
+                    alt="Dog photos"
+                    width={'100%'}
+                    height={'120'}
+                    style={{ objectFit: 'cover', borderRadius: '4px' }}
+                  />
+                </Grid>
+              );
+            })}
+          </Grid>
         </Stack>
-        <Typography variant="h5" fontWeight="bold" marginTop={4} paddingLeft={7} alignSelf="start">
-          About Me
-        </Typography>
-        <Typography variant="body1" marginTop={2} paddingX={7}>
-          {card.description}
-        </Typography>
-        <Grid container spacing={2} sx={{ paddingX: 7, marginTop: 4, marginBottom: 8 }}>
-          {card.images.map((item) => {
-            return (
-              <Grid item xs={4} sm={3} md={3} lg={2.4} xl={2} key={item.toString()}>
-                <img
-                  src={item}
-                  alt="Dog photos"
-                  width={'100%'}
-                  height={'120'}
-                  style={{ objectFit: 'cover', borderRadius: '4px' }}
-                />
-              </Grid>
-            );
-          })}
-        </Grid>
-      </Stack>
-    </Paper>
+      </CardContent>
+    </Card>
   );
 }

--- a/client/src/pages/Profile/DetailsCard/DetailsCard.tsx
+++ b/client/src/pages/Profile/DetailsCard/DetailsCard.tsx
@@ -1,26 +1,37 @@
 import { Paper, Typography, Stack, Avatar, Grid } from '@mui/material';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 
-export default function DetailsCard(): JSX.Element {
-  const coverImg = 'https://images.unsplash.com/photo-1625603736199-775425d2890a';
-  const avatarImg = 'https://images.unsplash.com/photo-1488716656724-3c8820d714a0';
+interface detailsCardData {
+  coverImg: string;
+  avatarImg: string;
+  images: string[];
+  name: string;
+  subtitle: string;
+  location: string;
+  description: string;
+}
 
-  const images = [
-    'https://images.unsplash.com/photo-1610968755695-d7fcb5fd4b92',
-    'https://images.unsplash.com/photo-1587300003388-59208cc962cb',
-  ];
-  const name = 'Norma Byers';
-  const subtitle = 'Loving pet sitter';
-  const location = 'Toronto, Ontario';
-  const description = `Animals are my passion! I will look after your pets with loving care. 
-  I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, 
-  and have owned multiple pets for many years, including numerous rescues. Kindly email, text, or call me and I will respond promptly!`;
+export default function DetailsCard(): JSX.Element {
+  const card: detailsCardData = {
+    coverImg: 'https://images.unsplash.com/photo-1625603736199-775425d2890a',
+    avatarImg: 'https://images.unsplash.com/photo-1488716656724-3c8820d714a0',
+    images: [
+      'https://images.unsplash.com/photo-1610968755695-d7fcb5fd4b92',
+      'https://images.unsplash.com/photo-1587300003388-59208cc962cb',
+    ],
+    name: 'Norma Byers',
+    subtitle: 'Loving pet sitter',
+    location: 'Toronto, Ontario',
+    description: `Animals are my passion! I will look after your pets with loving care. 
+    I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, 
+    and have owned multiple pets for many years, including numerous rescues. Kindly email, text, or call me and I will respond promptly!`,
+  };
 
   return (
     <Paper elevation={3}>
       <Stack direction="column" justifyContent="center" alignItems="center">
         <img
-          src={coverImg}
+          src={card.coverImg}
           alt="Cover photo"
           width="100%"
           height="300"
@@ -28,29 +39,29 @@ export default function DetailsCard(): JSX.Element {
         />
         <Avatar
           alt="Avatar photo"
-          src={avatarImg}
+          src={card.avatarImg}
           sx={{ height: 200, width: 200, border: '7px solid white', boxShadow: '2px 3px 20px 2px rgb(0 0 0 / 10%)' }}
         />
         <Typography variant="h4" marginTop={2} fontWeight="bold">
-          {name}
+          {card.name}
         </Typography>
         <Typography variant="subtitle1" color="text.disabled" fontWeight="bold">
-          {subtitle}
+          {card.subtitle}
         </Typography>
         <Stack direction="row" spacing={1} marginTop={3}>
           <LocationOnIcon color="primary"></LocationOnIcon>
           <Typography variant="subtitle1" color="text.disabled" fontWeight="bold">
-            {location}
+            {card.location}
           </Typography>
         </Stack>
         <Typography variant="h5" fontWeight="bold" marginTop={4} paddingLeft={7} alignSelf="start">
           About Me
         </Typography>
         <Typography variant="body1" marginTop={2} paddingX={7}>
-          {description}
+          {card.description}
         </Typography>
         <Grid container spacing={2} sx={{ paddingX: 7, marginTop: 4, marginBottom: 8 }}>
-          {images.map((item) => {
+          {card.images.map((item) => {
             return (
               <Grid item xs={4} sm={3} md={3} lg={2.4} xl={2} key={item.toString()}>
                 <img

--- a/client/src/pages/Profile/DetailsCard/DetailsCard.tsx
+++ b/client/src/pages/Profile/DetailsCard/DetailsCard.tsx
@@ -1,0 +1,70 @@
+import { Paper, Typography, Stack, Avatar, Grid } from '@mui/material';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+
+export default function DetailsCard(): JSX.Element {
+  const coverImg = 'https://images.unsplash.com/photo-1625603736199-775425d2890a';
+  const avatarImg = 'https://images.unsplash.com/photo-1488716656724-3c8820d714a0';
+
+  const images = [
+    'https://images.unsplash.com/photo-1610968755695-d7fcb5fd4b92',
+    'https://images.unsplash.com/photo-1587300003388-59208cc962cb',
+  ];
+  const name = 'Norma Byers';
+  const subtitle = 'Loving pet sitter';
+  const location = 'Toronto, Ontario';
+  const description = `Animals are my passion! I will look after your pets with loving care. 
+  I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, 
+  and have owned multiple pets for many years, including numerous rescues. Kindly email, text, or call me and I will respond promptly!`;
+
+  return (
+    <Paper elevation={3}>
+      <Stack direction="column" justifyContent="center" alignItems="center">
+        <img
+          src={coverImg}
+          alt="Cover photo"
+          width="100%"
+          height="300"
+          style={{ objectFit: 'cover', marginBottom: -100, borderRadius: '4px' }}
+        />
+        <Avatar
+          alt="Avatar photo"
+          src={avatarImg}
+          sx={{ height: 200, width: 200, border: '7px solid white', boxShadow: '2px 3px 20px 2px rgb(0 0 0 / 10%)' }}
+        />
+        <Typography variant="h4" marginTop={2} fontWeight="bold">
+          {name}
+        </Typography>
+        <Typography variant="subtitle1" color="text.disabled" fontWeight="bold">
+          {subtitle}
+        </Typography>
+        <Stack direction="row" spacing={1} marginTop={3}>
+          <LocationOnIcon color="primary"></LocationOnIcon>
+          <Typography variant="subtitle1" color="text.disabled" fontWeight="bold">
+            {location}
+          </Typography>
+        </Stack>
+        <Typography variant="h5" fontWeight="bold" marginTop={4} paddingLeft={7} alignSelf="start">
+          About Me
+        </Typography>
+        <Typography variant="body1" marginTop={2} paddingX={7}>
+          {description}
+        </Typography>
+        <Grid container spacing={2} sx={{ paddingX: 7, marginTop: 4, marginBottom: 8 }}>
+          {images.map((item) => {
+            return (
+              <Grid item xs={4} sm={3} md={3} lg={2.4} xl={2} key={item.toString()}>
+                <img
+                  src={item}
+                  alt="Dog photos"
+                  width={'100%'}
+                  height={'120'}
+                  style={{ objectFit: 'cover', borderRadius: '4px' }}
+                />
+              </Grid>
+            );
+          })}
+        </Grid>
+      </Stack>
+    </Paper>
+  );
+}

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -1,0 +1,31 @@
+import { Grid } from '@mui/material';
+import RequestCard from './RequestCard/RequestCard';
+import DetailsCard from './DetailsCard/DetailsCard';
+import PageContainer from '../../components/PageContainer/PageContainer';
+import { useParams } from 'react-router-dom';
+
+export default function ProfileDetails(): JSX.Element {
+  const { id } = useParams<{ id: string }>();
+
+  return (
+    <PageContainer>
+      <Grid
+        container
+        direction="row"
+        justifyContent="center"
+        alignItems="flex-start"
+        spacing={8}
+        paddingTop={2}
+        paddingBottom={7}
+        paddingX={{ xs: 2, sm: 10, md: 10 }}
+      >
+        <Grid item xs={12} sm={12} md={8}>
+          <DetailsCard />
+        </Grid>
+        <Grid item xs={12} sm={12} md={4}>
+          <RequestCard />
+        </Grid>
+      </Grid>
+    </PageContainer>
+  );
+}

--- a/client/src/pages/Profile/RequestCard/RequestCard.tsx
+++ b/client/src/pages/Profile/RequestCard/RequestCard.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { Paper, Typography, Rating, Button, Stack, TextField } from '@mui/material';
+import AdapterDateFns from '@mui/lab/AdapterDateFns';
+import LocalizationProvider from '@mui/lab/LocalizationProvider';
+import DateTimePicker from '@mui/lab/DateTimePicker';
+
+export default function RequestCard(): JSX.Element {
+  const hourlyRate = 14;
+  const rating = 4;
+  const [start, setStart] = useState<Date | null>(new Date());
+  const [end, setEnd] = useState<Date | null>(new Date());
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Paper elevation={3} sx={{ padding: 5 }}>
+        <Stack direction="column" justifyContent="flex-start" alignItems="center" spacing={5}>
+          {' '}
+          <Typography variant="h6" marginBottom={-4} sx={{ fontWeight: 'bold' }}>
+            ${hourlyRate}/hr
+          </Typography>
+          <Rating name="read-only" value={rating} size={'small'} readOnly />
+          <DateTimePicker
+            renderInput={(props) => <TextField {...props} />}
+            label="Drop In"
+            value={start}
+            onChange={(newValue) => {
+              setStart(newValue);
+            }}
+          />
+          <DateTimePicker
+            renderInput={(props) => <TextField {...props} />}
+            label="Drop Off"
+            value={end}
+            onChange={(newValue) => {
+              setEnd(newValue);
+            }}
+          />
+          <Button variant="contained" disableElevation sx={{ width: '60%', maxWidth: 180, height: 50 }}>
+            Send Request
+          </Button>
+        </Stack>
+      </Paper>
+    </LocalizationProvider>
+  );
+}

--- a/client/src/pages/Profile/RequestCard/RequestCard.tsx
+++ b/client/src/pages/Profile/RequestCard/RequestCard.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
 import { Paper, Typography, Rating, Button, Stack, TextField } from '@mui/material';
-import AdapterDateFns from '@mui/lab/AdapterDateFns';
-import LocalizationProvider from '@mui/lab/LocalizationProvider';
 import DateTimePicker from '@mui/lab/DateTimePicker';
 
 export default function RequestCard(): JSX.Element {
@@ -11,35 +9,33 @@ export default function RequestCard(): JSX.Element {
   const [end, setEnd] = useState<Date | null>(new Date());
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
-      <Paper elevation={3} sx={{ padding: 5 }}>
-        <Stack direction="column" justifyContent="flex-start" alignItems="center" spacing={5}>
-          {' '}
-          <Typography variant="h6" marginBottom={-4} sx={{ fontWeight: 'bold' }}>
-            ${hourlyRate}/hr
-          </Typography>
-          <Rating name="read-only" value={rating} size={'small'} readOnly />
-          <DateTimePicker
-            renderInput={(props) => <TextField {...props} />}
-            label="Drop In"
-            value={start}
-            onChange={(newValue) => {
-              setStart(newValue);
-            }}
-          />
-          <DateTimePicker
-            renderInput={(props) => <TextField {...props} />}
-            label="Drop Off"
-            value={end}
-            onChange={(newValue) => {
-              setEnd(newValue);
-            }}
-          />
-          <Button variant="contained" disableElevation sx={{ width: '60%', maxWidth: 180, height: 50 }}>
-            Send Request
-          </Button>
-        </Stack>
-      </Paper>
-    </LocalizationProvider>
+    <Paper elevation={3} sx={{ padding: 5 }}>
+      <Stack direction="column" justifyContent="flex-start" alignItems="center" spacing={5}>
+        {' '}
+        <Typography variant="h6" marginBottom={-4} sx={{ fontWeight: 'bold' }}>
+          ${hourlyRate}/hr
+        </Typography>
+        <Rating name="read-only" value={rating} size={'small'} readOnly />
+        <DateTimePicker
+          renderInput={(props) => <TextField {...props} />}
+          label="Drop In"
+          value={start}
+          onChange={(newValue) => {
+            setStart(newValue);
+          }}
+        />
+        <DateTimePicker
+          renderInput={(props) => <TextField {...props} />}
+          label="Drop Off"
+          value={end}
+          onChange={(newValue) => {
+            setEnd(newValue);
+          }}
+        />
+        <Button variant="contained" disableElevation sx={{ width: '60%', maxWidth: 180, height: 50 }}>
+          Send Request
+        </Button>
+      </Stack>
+    </Paper>
   );
 }

--- a/client/src/pages/Profile/RequestCard/RequestCard.tsx
+++ b/client/src/pages/Profile/RequestCard/RequestCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Paper, Typography, Rating, Button, Stack, TextField } from '@mui/material';
+import { Paper, Typography, Rating, Button, Stack, TextField, Card, CardContent } from '@mui/material';
 import DateTimePicker from '@mui/lab/DateTimePicker';
 
 export default function RequestCard(): JSX.Element {
@@ -9,33 +9,35 @@ export default function RequestCard(): JSX.Element {
   const [end, setEnd] = useState<Date | null>(new Date());
 
   return (
-    <Paper elevation={3} sx={{ padding: 5 }}>
-      <Stack direction="column" justifyContent="flex-start" alignItems="center" spacing={5}>
-        {' '}
-        <Typography variant="h6" marginBottom={-4} sx={{ fontWeight: 'bold' }}>
-          ${hourlyRate}/hr
-        </Typography>
-        <Rating name="read-only" value={rating} size={'small'} readOnly />
-        <DateTimePicker
-          renderInput={(props) => <TextField {...props} />}
-          label="Drop In"
-          value={start}
-          onChange={(newValue) => {
-            setStart(newValue);
-          }}
-        />
-        <DateTimePicker
-          renderInput={(props) => <TextField {...props} />}
-          label="Drop Off"
-          value={end}
-          onChange={(newValue) => {
-            setEnd(newValue);
-          }}
-        />
-        <Button variant="contained" disableElevation sx={{ width: '60%', maxWidth: 180, height: 50 }}>
-          Send Request
-        </Button>
-      </Stack>
-    </Paper>
+    <Card sx={{ padding: 3 }}>
+      <CardContent>
+        <Stack direction="column" justifyContent="flex-start" alignItems="center" spacing={5}>
+          {' '}
+          <Typography variant="h6" marginBottom={-4} sx={{ fontWeight: 'bold' }}>
+            ${hourlyRate}/hr
+          </Typography>
+          <Rating name="read-only" value={rating} size={'small'} readOnly />
+          <DateTimePicker
+            renderInput={(props) => <TextField {...props} />}
+            label="Drop In"
+            value={start}
+            onChange={(newValue) => {
+              setStart(newValue);
+            }}
+          />
+          <DateTimePicker
+            renderInput={(props) => <TextField {...props} />}
+            label="Drop Off"
+            value={end}
+            onChange={(newValue) => {
+              setEnd(newValue);
+            }}
+          />
+          <Button variant="contained" disableElevation sx={{ width: '60%', maxWidth: 180, height: 50 }}>
+            Send Request
+          </Button>
+        </Stack>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
### What this PR does (required):
- Creates the ui for the profile details page
- Closes #20 
- Profile data is currently hardcoded, to be integrated with user profiles in ticket #35 

### Screenshots / Videos (front-end only):
![Web capture_21-2-2022_45845_localhost](https://user-images.githubusercontent.com/25715300/155565086-7cdea031-ae67-4c2f-91b2-dc7dfdbde355.jpeg)


### Any information needed to test this feature (required):
- Log in as any user and access the page at http://localhost:3000/profile/:id, where :id can be any valid string

### Any issues with the current functionality (optional):
- The drop in/ drop off date pickers are different from the mockup, due to using mui's own styled datepicker.
