### PR TITLE
Integrate profile details page ui with server

### DIFF
--- a/client/src/components/Navbar/Navbar.tsx
+++ b/client/src/components/Navbar/Navbar.tsx
@@ -94,7 +94,7 @@ const Navbar: React.FC = () => {
   const location = useLocation();
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const { loggedInUser, logout } = useAuth();
+  const { loggedInUser, profile, logout } = useAuth();
   const open = Boolean(anchorEl);
 
   const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
@@ -168,7 +168,7 @@ const Navbar: React.FC = () => {
                     </ListItemIcon>
                     <ListItemText>Settings</ListItemText>
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={handleClose}>
+                  <DropdownMenuItem component={NavLink} to={`/profile/${profile?._id || ''}`} onClick={handleClose}>
                     <ListItemIcon>
                       <Person fontSize="small" />
                     </ListItemIcon>

--- a/client/src/helpers/APICalls/createRequest.ts
+++ b/client/src/helpers/APICalls/createRequest.ts
@@ -1,0 +1,18 @@
+import { RequestApiData } from '../../interface/RequestApiData';
+import { FetchOptions } from '../../interface/FetchOptions';
+
+const createRequest = async (sitterId: string, start: Date, end: Date): Promise<RequestApiData> => {
+  const fetchOptions: FetchOptions = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sitterId, start, end }),
+    credentials: 'include',
+  };
+  return await fetch(`/requests`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export default createRequest;

--- a/client/src/helpers/APICalls/getProfile.ts
+++ b/client/src/helpers/APICalls/getProfile.ts
@@ -1,0 +1,17 @@
+import { Profile, ProfileApiData } from '../../interface/Profile';
+import { FetchOptions } from '../../interface/FetchOptions';
+
+const getProfile = async (id: string): Promise<ProfileApiData> => {
+  const fetchOptions: FetchOptions = {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  };
+  return await fetch(`/profile/${id}`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export default getProfile;

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -6,3 +6,7 @@ export interface Profile {
   description?: string;
   photo?: string;
 }
+export interface ProfileApiData {
+  error?: { message: string };
+  success?: { profile: Profile };
+}

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -5,6 +5,17 @@ export interface Profile {
   address?: string;
   description?: string;
   photo?: string;
+  pay?: string;
+  headline?: string;
+  rating?: number;
+  name: string;
+  _id: string;
+  userId: string;
+}
+
+export interface SearchProfilesApiData {
+  profiles?: Profile[];
+  error?: { message: string };
 }
 export interface ProfileApiData {
   error?: { message: string };

--- a/client/src/pages/Profile/DetailsCard/DetailsCard.tsx
+++ b/client/src/pages/Profile/DetailsCard/DetailsCard.tsx
@@ -1,6 +1,5 @@
-import { Paper, Typography, Stack, Avatar, Grid, Card, CardMedia, CardContent } from '@mui/material';
+import { Typography, Stack, Avatar, Grid, Card, CardMedia, CardContent } from '@mui/material';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
-import { Profile } from './../../../interface/Profile';
 
 interface props {
   name?: string;

--- a/client/src/pages/Profile/DetailsCard/DetailsCard.tsx
+++ b/client/src/pages/Profile/DetailsCard/DetailsCard.tsx
@@ -1,37 +1,32 @@
 import { Paper, Typography, Stack, Avatar, Grid, Card, CardMedia, CardContent } from '@mui/material';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
+import { Profile } from './../../../interface/Profile';
 
-interface detailsCardData {
-  coverImg: string;
-  avatarImg: string;
-  images: string[];
-  name: string;
-  subtitle: string;
-  location: string;
-  description: string;
+interface props {
+  name?: string;
+  photo?: string;
+  address?: string;
+  description?: string;
+  headline?: string;
 }
 
-export default function DetailsCard(): JSX.Element {
-  const card: detailsCardData = {
+export default function DetailsCard({ name, photo, address, description, headline }: props): JSX.Element {
+  const stock = {
     coverImg: 'https://images.unsplash.com/photo-1625603736199-775425d2890a',
-    avatarImg: 'https://images.unsplash.com/photo-1488716656724-3c8820d714a0',
     images: [
       'https://images.unsplash.com/photo-1610968755695-d7fcb5fd4b92',
       'https://images.unsplash.com/photo-1587300003388-59208cc962cb',
     ],
-    name: 'Norma Byers',
-    subtitle: 'Loving pet sitter',
-    location: 'Toronto, Ontario',
-    description: `Animals are my passion! I will look after your pets with loving care. 
-    I have some availability for pet care in my home as well. I have 10 yrs experience at the Animal Hospital, 
-    and have owned multiple pets for many years, including numerous rescues. Kindly email, text, or call me and I will respond promptly!`,
+    description: 'Animals are my passion! I look forward to caring for your pet!',
+    headline: 'Loving pet sitter',
+    location: 'North America',
   };
 
   return (
     <Card>
       <CardMedia
         component="img"
-        src={card.coverImg}
+        src={stock.coverImg}
         alt="Cover photo"
         width="100%"
         height="300"
@@ -41,29 +36,29 @@ export default function DetailsCard(): JSX.Element {
         <Stack direction="column" justifyContent="center" alignItems="center">
           <Avatar
             alt="Avatar photo"
-            src={card.avatarImg}
+            src={photo}
             sx={{ height: 200, width: 200, border: '7px solid white', boxShadow: '2px 3px 20px 2px rgb(0 0 0 / 10%)' }}
           />
           <Typography variant="h4" marginTop={2} fontWeight="bold">
-            {card.name}
+            {name}
           </Typography>
           <Typography variant="subtitle1" color="text.disabled" fontWeight="bold">
-            {card.subtitle}
+            {headline || stock.headline}
           </Typography>
           <Stack direction="row" spacing={1} marginTop={3}>
             <LocationOnIcon color="primary"></LocationOnIcon>
             <Typography variant="subtitle1" color="text.disabled" fontWeight="bold">
-              {card.location}
+              {address || stock.location}
             </Typography>
           </Stack>
           <Typography variant="h5" fontWeight="bold" marginTop={4} paddingX={4} alignSelf="start">
             About Me
           </Typography>
-          <Typography variant="body1" marginTop={2} paddingX={4}>
-            {card.description}
+          <Typography variant="body1" marginTop={2} paddingX={4} alignSelf="start">
+            {description || stock.description}
           </Typography>
           <Grid container spacing={2} sx={{ paddingX: 4, marginTop: 4, marginBottom: 4 }}>
-            {card.images.map((item) => {
+            {stock.images.map((item) => {
               return (
                 <Grid item xs={4} sm={3} md={3} lg={2.4} xl={2} key={item.toString()}>
                   <img

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -1,58 +1,68 @@
-import { Grid } from '@mui/material';
+import { useState, useEffect } from 'react';
+import { Redirect, useParams } from 'react-router-dom';
+import { CircularProgress, Grid, Stack } from '@mui/material';
 import RequestCard from './RequestCard/RequestCard';
 import DetailsCard from './DetailsCard/DetailsCard';
 import PageContainer from '../../components/PageContainer/PageContainer';
-import { useParams } from 'react-router-dom';
 import { Profile } from './../../interface/Profile';
 import getProfile from '../../helpers/APICalls/getProfile';
-import { useState, useEffect } from 'react';
+import NotFound from '../NotFound/NotFound';
 
 export default function ProfileDetails(): JSX.Element {
   const { id } = useParams<{ id: string }>();
-
-  const [isLoading, setLoading] = useState<boolean>(true);
   const [profile, setProfile] = useState<Profile>({} as Profile);
+  const [found, setFound] = useState<boolean | undefined>();
 
   useEffect(() => {
-    if (isLoading) {
-      getProfile(id).then((data) => {
-        if (data.error) {
-          console.error({ error: data.error.message });
-        } else if (data.success) {
-          setProfile(data.success.profile);
-          setLoading(false);
-        } else {
-          console.error({ data });
-        }
-      });
-    }
-  }, [id, isLoading]);
+    getProfile(id).then((data) => {
+      if (data.error) {
+        console.error({ error: data.error.message });
+        setFound(false);
+      } else if (data.success) {
+        setProfile(data.success.profile);
+        setFound(true);
+      } else {
+        console.error({ data });
+        setFound(false);
+      }
+    });
+  }, [id]);
+
+  if (found === false) return <NotFound />;
+
+  if (found === true) {
+    return (
+      <PageContainer>
+        <Grid
+          container
+          direction="row"
+          justifyContent="center"
+          alignItems="flex-start"
+          spacing={8}
+          paddingTop={2}
+          paddingBottom={7}
+          paddingX={{ xs: 2, sm: 10, md: 10 }}
+        >
+          <Grid item xs={12} sm={12} md={8}>
+            <DetailsCard
+              name={profile.name}
+              photo={profile.photo}
+              address={profile.address}
+              description={profile.description}
+              headline={profile.headline}
+            />
+          </Grid>
+          <Grid item xs={12} sm={12} md={4}>
+            <RequestCard pay={profile.pay} rating={profile.rating} sitterId={profile.userId} />
+          </Grid>
+        </Grid>
+      </PageContainer>
+    );
+  }
 
   return (
-    <PageContainer>
-      <Grid
-        container
-        direction="row"
-        justifyContent="center"
-        alignItems="flex-start"
-        spacing={8}
-        paddingTop={2}
-        paddingBottom={7}
-        paddingX={{ xs: 2, sm: 10, md: 10 }}
-      >
-        <Grid item xs={12} sm={12} md={8}>
-          <DetailsCard
-            name={profile.name}
-            photo={profile.photo}
-            address={profile.address}
-            description={profile.description}
-            headline={profile.headline}
-          />
-        </Grid>
-        <Grid item xs={12} sm={12} md={4}>
-          <RequestCard pay={profile.pay} rating={profile.rating} sitterId={profile.userId} />
-        </Grid>
-      </Grid>
-    </PageContainer>
+    <Stack alignItems="center" marginTop={'20vh'}>
+      <CircularProgress />
+    </Stack>
   );
 }

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react';
-import { Redirect, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { CircularProgress, Grid, Stack } from '@mui/material';
 import RequestCard from './RequestCard/RequestCard';
 import DetailsCard from './DetailsCard/DetailsCard';
+import NotFound from '../NotFound/NotFound';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import { Profile } from './../../interface/Profile';
 import getProfile from '../../helpers/APICalls/getProfile';
-import NotFound from '../NotFound/NotFound';
 
 export default function ProfileDetails(): JSX.Element {
   const { id } = useParams<{ id: string }>();

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -3,9 +3,30 @@ import RequestCard from './RequestCard/RequestCard';
 import DetailsCard from './DetailsCard/DetailsCard';
 import PageContainer from '../../components/PageContainer/PageContainer';
 import { useParams } from 'react-router-dom';
+import { Profile } from './../../interface/Profile';
+import getProfile from '../../helpers/APICalls/getProfile';
+import { useState, useEffect } from 'react';
 
 export default function ProfileDetails(): JSX.Element {
   const { id } = useParams<{ id: string }>();
+
+  const [isLoading, setLoading] = useState<boolean>(true);
+  const [profile, setProfile] = useState<Profile>({} as Profile);
+
+  useEffect(() => {
+    if (isLoading) {
+      getProfile(id).then((data) => {
+        if (data.error) {
+          console.error({ error: data.error.message });
+        } else if (data.success) {
+          setProfile(data.success.profile);
+          setLoading(false);
+        } else {
+          console.error({ data });
+        }
+      });
+    }
+  }, [id, isLoading]);
 
   return (
     <PageContainer>
@@ -20,10 +41,16 @@ export default function ProfileDetails(): JSX.Element {
         paddingX={{ xs: 2, sm: 10, md: 10 }}
       >
         <Grid item xs={12} sm={12} md={8}>
-          <DetailsCard />
+          <DetailsCard
+            name={profile.name}
+            photo={profile.photo}
+            address={profile.address}
+            description={profile.description}
+            headline={profile.headline}
+          />
         </Grid>
         <Grid item xs={12} sm={12} md={4}>
-          <RequestCard />
+          <RequestCard pay={profile.pay} rating={profile.rating} sitterId={profile.userId} />
         </Grid>
       </Grid>
     </PageContainer>

--- a/client/src/pages/Profile/RequestCard/RequestCard.tsx
+++ b/client/src/pages/Profile/RequestCard/RequestCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Paper, Typography, Rating, Button, Stack, TextField, Card, CardContent } from '@mui/material';
 import DateTimePicker from '@mui/lab/DateTimePicker';
+import createRequest from './../../../helpers/APICalls/createRequest';
 
 interface props {
   pay?: string;
@@ -11,6 +12,12 @@ interface props {
 export default function RequestCard({ pay, rating, sitterId }: props): JSX.Element {
   const [start, setStart] = useState<Date | null>(new Date());
   const [end, setEnd] = useState<Date | null>(new Date());
+
+  const handleSendRequest = () => {
+    if (sitterId && start && end) {
+      createRequest(sitterId, start, end);
+    }
+  };
 
   return (
     <Card sx={{ padding: 3 }}>
@@ -37,7 +44,12 @@ export default function RequestCard({ pay, rating, sitterId }: props): JSX.Eleme
               setEnd(newValue);
             }}
           />
-          <Button variant="contained" disableElevation sx={{ width: '60%', maxWidth: 180, height: 50 }}>
+          <Button
+            onClick={() => handleSendRequest()}
+            variant="contained"
+            disableElevation
+            sx={{ width: '60%', maxWidth: 180, height: 50 }}
+          >
             Send Request
           </Button>
         </Stack>

--- a/client/src/pages/Profile/RequestCard/RequestCard.tsx
+++ b/client/src/pages/Profile/RequestCard/RequestCard.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { Paper, Typography, Rating, Button, Stack, TextField, Card, CardContent } from '@mui/material';
+import { Typography, Rating, Stack, TextField, Card, CardContent } from '@mui/material';
 import DateTimePicker from '@mui/lab/DateTimePicker';
+import LoadingButton from '@mui/lab/LoadingButton';
 import createRequest from './../../../helpers/APICalls/createRequest';
-import { LoadingButton } from '@mui/lab';
 import { useSnackBar } from './../../../context/useSnackbarContext';
 
 interface props {

--- a/client/src/pages/Profile/RequestCard/RequestCard.tsx
+++ b/client/src/pages/Profile/RequestCard/RequestCard.tsx
@@ -2,9 +2,13 @@ import { useState } from 'react';
 import { Paper, Typography, Rating, Button, Stack, TextField, Card, CardContent } from '@mui/material';
 import DateTimePicker from '@mui/lab/DateTimePicker';
 
-export default function RequestCard(): JSX.Element {
-  const hourlyRate = 14;
-  const rating = 4;
+interface props {
+  pay?: string;
+  rating?: number;
+  sitterId?: string;
+}
+
+export default function RequestCard({ pay, rating, sitterId }: props): JSX.Element {
   const [start, setStart] = useState<Date | null>(new Date());
   const [end, setEnd] = useState<Date | null>(new Date());
 
@@ -14,9 +18,9 @@ export default function RequestCard(): JSX.Element {
         <Stack direction="column" justifyContent="flex-start" alignItems="center" spacing={5}>
           {' '}
           <Typography variant="h6" marginBottom={-4} sx={{ fontWeight: 'bold' }}>
-            ${hourlyRate}/hr
+            ${pay || 0}/hr
           </Typography>
-          <Rating name="read-only" value={rating} size={'small'} readOnly />
+          <Rating name="read-only" value={rating || 0} size={'small'} precision={0.5} readOnly />
           <DateTimePicker
             renderInput={(props) => <TextField {...props} />}
             label="Drop In"

--- a/server/controllers/profile.js
+++ b/server/controllers/profile.js
@@ -1,5 +1,3 @@
-
-   
 const Profile = require("../models/Profile");
 const asyncHandler = require("express-async-handler");
 
@@ -36,6 +34,57 @@ exports.loadProfile = asyncHandler(async (req, res, next) => {
   res.status(200).json({
     success: {
       profile: profile,
+    },
+  });
+});
+
+// @route GET /profile
+// @desc Get list of pet sitter profiles by location or get all
+// @access Public
+exports.searchProfiles = asyncHandler(async (req, res, next) => {
+  if (req.query.location) {
+    const profiles = await Profile.find({
+      accountType: "pet_sitter",
+      address: { $regex: req.query.location, $options: "i" },
+      pay: { $ne: null },
+    });
+
+    res.status(200).json({
+      profiles: profiles,
+    });
+  } else if (req.query.location === "") {
+    const profiles = await Profile.find({
+      accountType: "pet_sitter",
+      address: { $ne: null | "" },
+      pay: { $ne: null },
+    });
+
+    res.status(200).json({
+      profiles: profiles,
+    });
+  } else {
+    res.status(400).json({
+      error: {
+        message: "Bad Request",
+      },
+    });
+  }
+});
+
+// @route GET /profile/:id
+// @desc Get user profile data
+// @access Private
+exports.loadProfileById = asyncHandler(async (req, res, next) => {
+  const profile = await Profile.findOne({ _id: req.params.id });
+
+  if (!profile) {
+    res.status(401);
+    throw new Error("Not authorized");
+  }
+
+  res.status(200).json({
+    success: {
+      profile,
     },
   });
 });

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -1,13 +1,19 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const protect = require('../middleware/auth');
+const protect = require("../middleware/auth");
 const {
   editProfile,
   loadProfile,
-} = require('../controllers/profile');
+  searchProfiles,
+  loadProfileById,
+} = require("../controllers/profile");
 
-router.route('/edit').put(protect, editProfile);
+router.route("/edit").put(protect, editProfile);
 
-router.route('/load').get(protect, loadProfile);
+router.route("/load").get(protect, loadProfile);
+
+router.route("/search").get(searchProfiles);
+
+router.route("/:id").get(protect, loadProfileById);
 
 module.exports = router;


### PR DESCRIPTION
### What this PR does (required):
- Integrates #20 with dynamic data based on the user the profile is linked to.
- Implement the send request button to create a booking request on submit
- Adds a profile controller route to find a profile by it's id
- Adds link to navbar to access user's own profile
- Closes #35 

### Screenshots / Videos (front-end only):
![msedge_5UpPrf3zRc](https://user-images.githubusercontent.com/25715300/155641744-29e244a4-8204-4d6a-9e72-30d125609ec7.gif)


### Any information needed to test this feature (required):
- Sign up as a new user and log in
- Access your profile through the profile icon -> profile
- Access any other user's profile by entering the profile id in the url
- Test the send request button with a valid range of dates.
  - The start date must be after the current time.
  - The end date must be after the start date. 
  - An error notification will occur if an invalid date is sent.
- Note: since it is not possible to create a request to yourself, create request will fail on self profiles accessed through the navbar


### Any issues with the current functionality (optional):
- The cover photo and photos of the dogs are currently hardcoded. Its server implementation is out of scope for this ticket
- The profile avatar should load a user-uploaded photo from the Amazon S3, but I was unable to successfully upload a photo to test this feature. This may be due to a configuration issue on my end.
- When logging in as a user, accessing your profile through the navbar too quickly may result in loading a profile with an undefined id. It will then lead to a not found page. This is because the auth context is undefined by default before it is finished loading.
