### PR TITLE
Create notifications frontend & integration

### DIFF
--- a/client/src/components/Navbar/Navbar.tsx
+++ b/client/src/components/Navbar/Navbar.tsx
@@ -17,6 +17,7 @@ import lovingSitterLogo from '../../images/logo.svg';
 import { useStyles } from './useStyles';
 import { NavLink, useLocation } from 'react-router-dom';
 import { Settings, Logout, Person } from '@mui/icons-material';
+import NotificationMenu from '../NotificationMenu/NotificationMenu';
 
 const NavbarButton = styled(Button)({
   padding: '15px 0',
@@ -132,7 +133,12 @@ const Navbar: React.FC = () => {
         <img className={classes.navbarLogo} src={lovingSitterLogo} />
       </Grid>
       <Grid xs={8} md={6} item>
-        <Grid container alignItems="center" gap={2} justifyContent="flex-end">
+        <Grid container alignItems="center" gap={2} justifyContent="flex-end" wrap="nowrap">
+          {loggedInUser && (
+            <Grid xs={2} item>
+              <NotificationMenu />
+            </Grid>
+          )}
           {renderMenuItems()}
           {loggedInUser && (
             <Grid xs={2} item>

--- a/client/src/components/NotificationCard/NotificationCard.tsx
+++ b/client/src/components/NotificationCard/NotificationCard.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import Avatar from '@mui/material/Avatar';
+import { User } from '../../interface/User';
+import { Notification, NotificationType } from '../../interface/Notification';
+import { Menu, MenuItem, Button, Card, CardHeader, CardContent, CardActionArea, Typography, Box } from '@mui/material';
+import { getAll, getUnread, markAsRead, create } from '../../helpers/APICalls/notification';
+
+interface props {
+  notification: Notification;
+}
+
+export default function NotificationCard({ notification }: props): JSX.Element {
+  function displayDate(dateIn: string): string {
+    const dateOut = new Date(dateIn);
+    return dateOut.toLocaleDateString('en-US', { year: 'numeric', month: '2-digit', day: '2-digit' });
+  }
+
+  return (
+    <Card elevation={0} sx={{ display: 'flex', alignItems: 'center', paddingX: 2, background: 'transparent' }}>
+      <Avatar alt="Notification photo" variant="square" src={notification.photo} sx={{ width: 70, height: 70 }} />
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+        <CardContent>
+          <Typography variant="h6" fontWeight="bold" noWrap sx={{ marginBottom: -1 }}>
+            {notification.title}
+          </Typography>
+          <Typography
+            variant="subtitle1"
+            color="lightgray"
+            fontWeight="bold"
+            sx={{ textTransform: 'capitalize' }}
+            noWrap
+          >
+            {notification.description}
+          </Typography>
+          <Typography variant="h6" noWrap>
+            {displayDate(notification.date)}
+          </Typography>
+        </CardContent>
+      </Box>
+    </Card>
+  );
+}

--- a/client/src/components/NotificationCard/NotificationCard.tsx
+++ b/client/src/components/NotificationCard/NotificationCard.tsx
@@ -1,9 +1,5 @@
-import { useState } from 'react';
-import Avatar from '@mui/material/Avatar';
-import { User } from '../../interface/User';
-import { Notification, NotificationType } from '../../interface/Notification';
-import { Menu, MenuItem, Button, Card, CardHeader, CardContent, CardActionArea, Typography, Box } from '@mui/material';
-import { getAll, getUnread, markAsRead, create } from '../../helpers/APICalls/notification';
+import { Notification } from '../../interface/Notification';
+import { Card, CardContent, Typography, Box, Avatar } from '@mui/material';
 
 interface props {
   notification: Notification;

--- a/client/src/components/NotificationMenu/NotificationMenu.tsx
+++ b/client/src/components/NotificationMenu/NotificationMenu.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from 'react';
-import Avatar from '@mui/material/Avatar';
-import { User } from '../../interface/User';
 import { getAll, getUnread, markAsRead, create } from '../../helpers/APICalls/notification';
-import { Menu, MenuItem, Button, Grid, ButtonBase, Badge, Typography, MenuList } from '@mui/material';
+import { Menu, MenuItem, ButtonBase, Badge, Typography } from '@mui/material';
 import NotificationCard from '../NotificationCard/NotificationCard';
 import { useStyles } from '../Navbar/useStyles';
 import { Notification } from '../../interface/Notification';

--- a/client/src/components/NotificationMenu/NotificationMenu.tsx
+++ b/client/src/components/NotificationMenu/NotificationMenu.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react';
+import Avatar from '@mui/material/Avatar';
+import { User } from '../../interface/User';
+import { getAll, getUnread, markAsRead, create } from '../../helpers/APICalls/notification';
+import { Menu, MenuItem, Button, Grid, ButtonBase, Badge, Typography, MenuList } from '@mui/material';
+import NotificationCard from '../NotificationCard/NotificationCard';
+import { useStyles } from '../Navbar/useStyles';
+import { Notification } from '../../interface/Notification';
+import { NavLink } from 'react-router-dom';
+import { theme } from '../../themes/theme';
+import { useSnackBar } from '../../context/useSnackbarContext';
+
+export default function NotificationMenu(): JSX.Element {
+  const classes = useStyles();
+  const { updateSnackBarMessage } = useSnackBar();
+  const [buttonColor, setButtonColor] = useState(theme.palette.grey[700]);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const openMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+    setButtonColor(theme.palette.primary.main);
+  };
+  const closeMenu = () => {
+    setAnchorEl(null);
+    setButtonColor(theme.palette.grey[700]);
+  };
+  const readAndCloseMenu = (notifId: string) => {
+    markAsRead(notifId);
+    closeMenu();
+  };
+
+  const [notifications, setNotifications] = useState<null | Notification[]>(null);
+  useEffect(() => {
+    if (open) return;
+    getUnread().then((data) => {
+      if (data.error) {
+        updateSnackBarMessage(data.error.message);
+      } else if (data.success) {
+        setNotifications(data.success.notifications);
+      } else {
+        updateSnackBarMessage('An unexpected error occurred. Please try again');
+      }
+    });
+  }, [open, updateSnackBarMessage]);
+
+  const renderNotifications = () => {
+    if (notifications?.length) {
+      return notifications.map((notif) => {
+        return (
+          <MenuItem
+            key={notif._id}
+            sx={{ marginY: -1 }}
+            component={NavLink}
+            to={notif.link}
+            onClick={() => readAndCloseMenu(notif._id)}
+          >
+            <NotificationCard notification={notif} />
+          </MenuItem>
+        );
+      });
+    } else {
+      return (
+        <Typography variant="subtitle1" color="text.disabled" fontWeight="bold" paddingX={2} paddingY={0.5}>
+          No New Notifications
+        </Typography>
+      );
+    }
+  };
+
+  return (
+    <>
+      <Badge color="info" variant="dot" invisible={notifications?.length ? false : true}>
+        <ButtonBase
+          className={classes.navbarItem}
+          sx={{ color: buttonColor }}
+          aria-label="notifications"
+          aria-controls="menu-navbar"
+          arais-haspopup="true"
+          onClick={openMenu}
+        >
+          Notifications
+        </ButtonBase>
+        <Menu
+          id="menu-notifications"
+          anchorEl={anchorEl}
+          open={open}
+          onClose={closeMenu}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+        >
+          {renderNotifications()}
+        </Menu>
+      </Badge>
+    </>
+  );
+}

--- a/client/src/helpers/APICalls/notification.ts
+++ b/client/src/helpers/APICalls/notification.ts
@@ -1,0 +1,57 @@
+import { NotificationApiData, NotificationType } from '../../interface/Notification';
+import { FetchOptions } from '../../interface/FetchOptions';
+
+export const getAll = async (): Promise<NotificationApiData> => {
+  const fetchOptions: FetchOptions = {
+    method: 'GET',
+    credentials: 'include',
+  };
+  return await fetch(`/notifications`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export const getUnread = async (): Promise<NotificationApiData> => {
+  const fetchOptions: FetchOptions = {
+    method: 'GET',
+    credentials: 'include',
+  };
+  return await fetch(`/notifications/unread`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export const markAsRead = async (id: string): Promise<NotificationApiData> => {
+  const fetchOptions: FetchOptions = {
+    method: 'PUT',
+    credentials: 'include',
+  };
+  return await fetch(`/notifications/${id}`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export const create = async (
+  title: string,
+  description: string,
+  type: NotificationType,
+  link: string,
+): Promise<NotificationApiData> => {
+  const fetchOptions: FetchOptions = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title, description, type, link }),
+    credentials: 'include',
+  };
+  return await fetch(`/notifications`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};

--- a/client/src/interface/Notification.ts
+++ b/client/src/interface/Notification.ts
@@ -1,0 +1,29 @@
+import { User } from './User';
+
+export enum NotificationType {
+  booking = 'booking',
+  payment = 'payment',
+  system = 'system',
+}
+
+export enum NotificationStatus {
+  read = 'read',
+  unread = 'unread',
+}
+
+export interface Notification {
+  _id: string;
+  user: User;
+  title: string;
+  description: string;
+  photo: string;
+  type: NotificationType;
+  link: string;
+  status: NotificationStatus;
+  date: string;
+}
+
+export interface NotificationApiData {
+  error?: { message: string };
+  success?: { notifications: Notification[] };
+}


### PR DESCRIPTION
### What this PR does (required):
- Implements and integrates notifications frontend through a navbar menu
- Creates frontend interface, api, and menu components
- The notifications menu performs api requests to check for new notifications on first load and whenever it closes
- Shows a badge when there are unread notifications
- Clicking a notification will redirect to it's linked page, mark it as read, and it will be removed from the menu
- When the menu is empty, the notifications badge will be hidden and "no new notifications" will be displayed
- Closes #27 

### Screenshots / Videos (front-end only):
![msedge_6UbpnzF8MT](https://user-images.githubusercontent.com/25715300/157118360-66e73f41-0c92-4044-a14b-7c3f4dbe3d8d.gif)


### Any information needed to test this feature (required):
- Create notifications through backend api #69 
- Login as user, notifications will be displayed in navbar menu
- Click a notification to be redirected to it's linked page, and it will be removed from the menu afterwards
- The list of notifications is updated whenever the menu closes

### Any issues with the current functionality (optional):
- While the frontend & backend api's for creating a notification exists and is implemented, it not called throughout the app when events occur (such as creating a booking). Notifications must be manually created at this time.