### PR TITLE
Integrate static dashboard with profile page links

### DIFF
--- a/client/src/components/Cards/ProfileCard.tsx
+++ b/client/src/components/Cards/ProfileCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardActionArea, CardContent, Typography, Rating, Box, Avatar } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
+import { Link } from 'react-router-dom';
 
 const useStyles = makeStyles({
   root: {
@@ -29,6 +30,7 @@ const useStyles = makeStyles({
 });
 
 interface ProfileCardProps {
+  id: string;
   photo: string;
   name: string;
   caption?: string;
@@ -38,11 +40,11 @@ interface ProfileCardProps {
   pay: number;
 }
 
-const ProfileCard: React.FC<ProfileCardProps> = ({ photo, name, caption, rating, description, location, pay }) => {
+const ProfileCard: React.FC<ProfileCardProps> = ({ id, photo, name, caption, rating, description, location, pay }) => {
   const classes = useStyles();
   return (
     <Card className={classes.root}>
-      <CardActionArea>
+      <CardActionArea component={Link} to={`/profile/${id}`}>
         <CardContent sx={{ display: 'flex', flexDirection: 'column', justifyItems: 'center' }}>
           <Avatar alt="Profile Photo" src={photo} className={classes.avatar} />
           <Typography variant="h5" component="h2" fontWeight="500" textAlign="center">

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -8,7 +8,7 @@ export interface Profile {
   description?: string;
   photo?: string;
   pay?: string;
-  headline?: string;
+  caption?: string;
   rating?: number;
   name: string;
   _id: string;

--- a/client/src/pages/Dashboard/Dashboard.tsx
+++ b/client/src/pages/Dashboard/Dashboard.tsx
@@ -20,7 +20,7 @@ export default function Dashboard(): JSX.Element {
 
   const profileCards = [
     {
-      id: 'b5a02958-e5ff-4969-ad3b-0d2ddc5f129e',
+      id: '62274f86ca736209156a6eec',
       name: 'Norma Byers',
       photo:
         'https://images.unsplash.com/photo-1525134479668-1bee5c7c6845?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80',
@@ -31,7 +31,7 @@ export default function Dashboard(): JSX.Element {
       pay: 14,
     },
     {
-      id: '2dfb07e8-980a-4e9f-a7e2-4c87479ae627',
+      id: '62274f97ca736209156a6ef3',
       name: 'Jessica Pearson',
       photo:
         'https://images.unsplash.com/photo-1606122017369-d782bbb78f32?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=764&q=80',
@@ -42,40 +42,7 @@ export default function Dashboard(): JSX.Element {
       pay: 15,
     },
     {
-      id: '86689e76-b4c3-41a1-9e68-9bffe4291df5',
-      name: 'Charles Compton',
-      photo:
-        'https://images.unsplash.com/photo-1484517186945-df8151a1a871?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1949&q=80',
-      caption: 'Passionate pet sitter',
-      rating: 5,
-      description: 'I provide dog walking and pet sitting services',
-      location: 'Toronto, Ontario',
-      pay: 20,
-    },
-    {
-      id: 'aa523eb0-ca63-40a8-8f6d-75b023f3296f',
-      name: 'Norma Byers',
-      photo:
-        'https://images.unsplash.com/photo-1525134479668-1bee5c7c6845?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80',
-      caption: 'Loving pet sitter',
-      rating: 4.5,
-      description: 'Dog sitting, cat sitting, pocket pet and bird care',
-      location: 'Toronto, Ontario',
-      pay: 14,
-    },
-    {
-      id: 'df8ea58a-0101-4958-9612-50faeee53721',
-      name: 'Jessica Pearson',
-      photo:
-        'https://images.unsplash.com/photo-1606122017369-d782bbb78f32?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=764&q=80',
-      caption: 'Loving pet sitter',
-      rating: 4,
-      description: 'I have had dogs as pets for most of my life',
-      location: 'Toronto, Ontario',
-      pay: 15,
-    },
-    {
-      id: 'a6bdc99c-3378-4737-8a40-603a75403c34',
+      id: '62274fa5ca736209156a6efa',
       name: 'Charles Compton',
       photo:
         'https://images.unsplash.com/photo-1484517186945-df8151a1a871?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1949&q=80',

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -49,7 +49,7 @@ export default function ProfileDetails(): JSX.Element {
               photo={profile.photo}
               address={profile.address}
               description={profile.description}
-              headline={profile.headline}
+              headline={profile.caption}
             />
           </Grid>
           <Grid item xs={12} sm={12} md={4}>

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -4,14 +4,18 @@ const profileSchema = new mongoose.Schema({
   userId: {
     type: mongoose.Schema.Types.ObjectId,
     required: true,
-    ref: 'User',
+    ref: "User",
   },
   accountType: {
     type: String,
     default: "pet_owner",
-    enum: ['pet_owner', 'pet_sitter'],
+    enum: ["pet_owner", "pet_sitter"],
   },
   name: {
+    type: String,
+    default: "",
+  },
+  caption: {
     type: String,
     default: "",
   },
@@ -21,7 +25,7 @@ const profileSchema = new mongoose.Schema({
   },
   gender: {
     type: String,
-    enum: ['male', 'female', 'other'],
+    enum: ["male", "female", "other"],
   },
   address: {
     type: String,
@@ -33,11 +37,19 @@ const profileSchema = new mongoose.Schema({
   },
   birthday: {
     type: Date,
-    default: null
+    default: null,
   },
   photo: {
     type: String,
     default: "",
+  },
+  pay: {
+    type: String,
+    default: "",
+  },
+  rating: {
+    type: Number,
+    default: 0,
   },
 });
 


### PR DESCRIPTION
### What this PR does (required):
- Modifies the dashboard so that each profile card links it its relevant profile page by profile id

### Screenshots / Videos (front-end only):
https://user-images.githubusercontent.com/25715300/157259216-d12e7ab7-ccb1-43bf-94e2-943fed9027b5.mp4

### Any information needed to test this feature (required):
- Create an account through the sign up link
- Click on any profile card on the dashboard

### Any issues with the current functionality (optional):
- Dashboard profile cards are currently hardcoded
