### PR TITLE
Implement profile card links to profile page

### DIFF
--- a/client/src/components/Cards/ProfileCard.tsx
+++ b/client/src/components/Cards/ProfileCard.tsx
@@ -2,6 +2,7 @@ import { Card, CardActionArea, CardContent, Typography, Rating, Box, Avatar } fr
 import { makeStyles } from '@mui/styles';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import { Profile } from '../../interface/Profile';
+import { Link } from 'react-router-dom';
 
 const useStyles = makeStyles({
   root: {
@@ -37,7 +38,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({ profile }) => {
   const classes = useStyles();
   return (
     <Card className={classes.root}>
-      <CardActionArea>
+      <CardActionArea component={Link} to={`/profile/${profile._id}`}>
         <CardContent sx={{ display: 'flex', flexDirection: 'column', justifyItems: 'center' }}>
           <Avatar alt="Profile Photo" src={profile.photo} className={classes.avatar} />
           <Typography variant="h5" component="h2" fontWeight="500" textAlign="center">


### PR DESCRIPTION
### What this PR does (required):
- Modifies the dashboard so that each profile card links it its relevant profile page by profile id
### Screenshots / Videos (front-end only):
https://user-images.githubusercontent.com/25715300/157265470-191e547c-0590-421d-9a15-0bf5f5eeabfb.mp4



### Any information needed to test this feature (required):
- Create an account through the sign up link
- Create users&profiles through mongo database or api tool
- Click on any profile card on the dashboard
